### PR TITLE
Fix: Catch exceptions on loading images

### DIFF
--- a/Slide/Slide.csproj
+++ b/Slide/Slide.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Prism.Wpf" Version="8.1.97" />
     <PackageReference Include="ReactiveProperty" Version="9.3.4" />
     <PackageReference Include="ReactiveProperty.WPF" Version="9.3.4" />
+    <PackageReference Include="System.Drawing.Primitives" Version="4.3.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Fix: 画像ロード時の例外でプログラムが落ちる
- System.Windows.Media.Imagingで読み込めない画像ファイルを読み込むためにSystem.Drawingを使用する